### PR TITLE
fix rollup configuration for AoT build

### DIFF
--- a/index-aot.html
+++ b/index-aot.html
@@ -27,7 +27,8 @@
 
 <script type="text/javascript">
 window.module = 'aot';
+// use the dojo loader to require and execute the bundle
+require(['dist/build.js']);
 </script>
-<script src="dist/build.js"/>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -70,9 +70,7 @@
     "rollup": "^0.41.4",
     "rollup-plugin-alias": "^1.2.0",
     "rollup-plugin-amd": "^1.2.0",
-    "rollup-plugin-bower-resolve": "^0.2.0",
     "rollup-plugin-commonjs": "^7.0.0",
-    "rollup-plugin-ignore": "^1.0.3",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-uglify": "^1.0.1",
     "typescript": "~2.1.6"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,8 +2,6 @@ import rollup      from 'rollup'
 import nodeResolve from 'rollup-plugin-node-resolve'
 import commonjs    from 'rollup-plugin-commonjs';
 import uglify      from 'rollup-plugin-uglify'
-import ignore from 'rollup-plugin-ignore';
-import bowerResolve from 'rollup-plugin-bower-resolve';
 
 export default {
   entry: 'src/main-aot.js',
@@ -11,8 +9,7 @@ export default {
   sourceMap: false,
   format: 'amd',
   plugins: [
-      nodeResolve({jsnext: true, module: true}),
-      bowerResolve({
+      nodeResolve({
         jsnext: true,
         module: true,
         skip: ['esri']
@@ -20,7 +17,6 @@ export default {
       commonjs({
         include: 'node_modules/rxjs/**',
       }),
-      ignore(['esri/*']),
       uglify()
   ]
 }


### PR DESCRIPTION
The issue was that you needed to configure the node resolve plugin to skip esri. After that, the bower resolve and ignore plugins were no longer needed.

After making these changes I was able to successfully run `npm run build-aot` and then load server the index-aot.html from a local web server and it worked.

resolves #2 
